### PR TITLE
Require lightbox: true for HTML reports in ibl-report skill

### DIFF
--- a/skills/ibl-report/SKILL.md
+++ b/skills/ibl-report/SKILL.md
@@ -37,6 +37,8 @@ The report should have the following sections:
 
 ## Figures
 
+For HTML reports (`format: html`), always set `lightbox: true` in the YAML header so figures are clickable/zoomable. This option has no effect on PDF reports (`format: pdf`).
+
 The report should contain plentiful figures. Include all figures made in the original research except for "dead ends" that did not lead to the main results. Make new figures if necessary for illustration purposes, but do not conduct new research in the writeup phase.
 
 ## AI instruction file suggestions


### PR DESCRIPTION
## Summary
- Update `skills/ibl-report/SKILL.md` to require `lightbox: true` in the YAML header of every HTML report (no effect on PDF reports).
- Verified by rendering the three existing HTML reports and confirming GLightbox assets are embedded in the output.