### PR TITLE
Add concise communication and report prose style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,13 @@ Keep a running summary of the explicated question and term definitions in `proje
 Both `TODO.md` and `question.md` can be dynamic: as exploration proceeds, the question and TODO items not yet performed can change.  But don't change items already completed. When making changes to either file, save in `projects/<project_slug>/change-log.md`
 
 
+## Communication style
+
+Be terse. State results and decisions directly; do not restate context or recap what was just done. End-of-turn summaries: 1-2 sentences max.
+
 ## Context-window diagnostics
 
-Always tell the user when you read a skill or reference file into context, and why you did it. If you read only part of a file, say which part and why.
+Only mention reading a skill or reference file when it materially changes what the user should expect (large file, changed plan) — not as a routine announcement for every read.
 
 ## Required Load Packets
 

--- a/skills/ibl-report/SKILL.md
+++ b/skills/ibl-report/SKILL.md
@@ -35,6 +35,10 @@ The report should have the following sections:
   - Include any caveats of this result (positive or negative)
   - Describe any lessons learned for future AI-based analyses of this data
 
+## Prose style
+
+State findings directly: figure + 1-2 sentence caption/interpretation. No boilerplate transitions or restating section purpose.
+
 ## Figures
 
 For HTML reports (`format: html`), always set `lightbox: true` in the YAML header so figures are clickable/zoomable. This option has no effect on PDF reports (`format: pdf`).


### PR DESCRIPTION
## Summary
- Stacked on #31.
- Add `Communication style` to AGENTS.md (terse responses, short summaries) and soften the context-window diagnostics rule to reduce narration noise.
- Add `Prose style` to ibl-report/SKILL.md: state findings directly, no boilerplate transitions.

Addresses user feedback that agent reports and chat communication were too verbose.

This is perhaps more controversial, so happy to discuss and or whether this should stay on a separate branch for testing for now. 